### PR TITLE
Pipe password instead of giving it as argument

### DIFF
--- a/passmenu-rofi-wayland
+++ b/passmenu-rofi-wayland
@@ -18,5 +18,5 @@ password=$(printf '%s\n' "${password_files[@]}" | rofi -dmenu "$@")
 [[ -n $password ]] || exit
 
 if [[ $typeit -eq 0 ]]; then
-	wl-copy $(pass show "$password" | head -1) & sleep 45s && wl-copy -c
+	pass show "$password" | head -1 | wl-copy & sleep 45s && wl-copy -c
 fi


### PR DESCRIPTION
Giving a password as argument to a command makes it visible in the
output of `ps` or in /proc/$(pidof wl-copy)/cmdline. Piping it into
wl-copy doesn't create this problem.